### PR TITLE
fix/closure-return-borrow

### DIFF
--- a/src/std/string_view.spp
+++ b/src/std/string_view.spp
@@ -364,13 +364,15 @@ sup StrView {
 
     !public
     !versioned(base="1.0.0", new="1.0.0")
-    fun lines(&self) -> Iterator[&StrView] {
+    cor lines(&self) -> Iterator[&StrView] {
         #
         # @ret:
 
         # Map to splitting by all "\n" and then trim the trailing "\r" from each line.
         let mut sep = "\n"
-        ret self.split(sep).map((line: &StrView) line.trim_end())
+        loop line in self.split(sep) {
+            gen line.trim_end()
+        }
     }
 
     !public


### PR DESCRIPTION
Fix bug where borrows could be returned from closures as the return type self-inferred from the expressions inside the closure. Also update a subroutine to a coroutine.