### PR TITLE
fix/visibility-defaults-init

### DIFF
--- a/src/std/mem/raw_buf.spp
+++ b/src/std/mem/raw_buf.spp
@@ -27,7 +27,7 @@ use std::mem::pointer::NonNull
 use std::ops::idx::IndexMut
 use std::ops::idx::IndexRef
 
-!package
+!public
 !versioned(base="1.0.0", new="1.0.0")
 cls RawBuf[T, A: Alloc=GlobalAlloc] {
     # The `RawBuf` type is a low level container for contiguous elements in memory. It is capacity aware, but not length


### PR DESCRIPTION
Fix the visibility for when a type is an attribute of another type being default initialized. Because visibility propagates: `let x = X()` - if `X` has attribute `A` then it will get default initialized, but has to be accessible from the calling context in that case. Only one case - `RawBuf`. Look at restricting this in the future anyway for safety.